### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Toolset for generating PHP code",
     "keywords": ["code generation"],
     "type": "library",
-    "license": "Apache2",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Johannes M. Schmitt",


### PR DESCRIPTION
Apache-2.0 is the recommended notation for the Apache 2.0 license. It is also consistent with di-extra-bundle and aop-bundle.
