### PR TITLE
PHP7.1 - added support for nullable return & param types

### DIFF
--- a/src/CG/Generator/BuiltinType.php
+++ b/src/CG/Generator/BuiltinType.php
@@ -12,7 +12,7 @@ class BuiltinType
 
     public static function isBuiltin($type)
     {
-        return in_array($type, static::$builtinTypes);
+        return in_array(ltrim($type, '?'), static::$builtinTypes);
     }
 }
     

--- a/src/CG/Generator/PhpFunction.php
+++ b/src/CG/Generator/PhpFunction.php
@@ -49,7 +49,7 @@ class PhpFunction extends AbstractBuilder
 
         if (method_exists($ref, 'getReturnType')) {
             if ($type = $ref->getReturnType()) {
-                $function->setReturnType((string)$type);
+                $function->setReturnType($type);
             }
         }
         $function->referenceReturned = $ref->returnsReference();
@@ -133,10 +133,18 @@ class PhpFunction extends AbstractBuilder
         return $this;
     }
 
+    /**
+     * @param \ReflectionType|string $type
+     * @return $this
+     */
     public function setReturnType($type)
     {
+        if ($type instanceof \ReflectionType) {
+            $type = ($type->allowsNull() ? '?' : '') . $type->getName();
+        }
+
         $this->returnType = $type;
-        $this->returnTypeBuiltin = BuiltinType::isBuiltIn($type);
+        $this->returnTypeBuiltin = BuiltinType::isBuiltin($type);
         return $this;
     }
 

--- a/src/CG/Generator/PhpMethod.php
+++ b/src/CG/Generator/PhpMethod.php
@@ -52,12 +52,11 @@ class PhpMethod extends AbstractPhpMember
             ->setStatic($ref->isStatic())
             ->setVisibility($ref->isPublic() ? self::VISIBILITY_PUBLIC : ($ref->isProtected() ? self::VISIBILITY_PROTECTED : self::VISIBILITY_PRIVATE))
             ->setReferenceReturned($ref->returnsReference())
-            ->setName($ref->name)
-        ;
+            ->setName($ref->name);
 
         if (method_exists($ref, 'getReturnType')) {
             if ($type = $ref->getReturnType()) {
-                $method->setReturnType((string)$type);
+                $method->setReturnType($type);
             }
         }
 
@@ -106,7 +105,7 @@ class PhpMethod extends AbstractPhpMember
      */
     public function setReferenceReturned($bool)
     {
-        $this->referenceReturned = (Boolean) $bool;
+        $this->referenceReturned = (Boolean)$bool;
 
         return $this;
     }
@@ -135,8 +134,16 @@ class PhpMethod extends AbstractPhpMember
         return $this;
     }
 
+    /**
+     * @param \ReflectionType|string $type
+     * @return $this
+     */
     public function setReturnType($type)
     {
+        if ($type instanceof \ReflectionType) {
+            $type = ($type->allowsNull() ? '?' : '') . $type->getName();
+        }
+
         $this->returnType = $type;
         $this->returnTypeBuiltin = BuiltinType::isBuiltin($type);
         return $this;

--- a/src/CG/Generator/PhpParameter.php
+++ b/src/CG/Generator/PhpParameter.php
@@ -30,7 +30,7 @@ class PhpParameter extends AbstractBuilder
     private $hasDefaultValue = false;
     private $passedByReference = false;
     private $type;
-    private $typeBuiltin;
+    private $typeBuiltin = false;
 
     /**
      * @param string|null $name
@@ -54,7 +54,7 @@ class PhpParameter extends AbstractBuilder
 
         if (method_exists($ref, 'getType')) {
             if ($type = $ref->getType()) {
-                $parameter->setType((string)$type);
+                $parameter->setType($type);
             }
         } else {
             if ($ref->isArray()) {
@@ -111,10 +111,13 @@ class PhpParameter extends AbstractBuilder
     }
 
     /**
-     * @param string $type
+     * @param \ReflectionType|string $type
      */
     public function setType($type)
     {
+        if ($type instanceof \ReflectionType) {
+            $type = ($type->allowsNull() ? '?' : '') . $type->getName();
+        }
         $this->type = $type;
         $this->typeBuiltin = BuiltinType::isBuiltIn($type);
 

--- a/tests/CG/Tests/Generator/Php71FunctionTest.php
+++ b/tests/CG/Tests/Generator/Php71FunctionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CG\Tests\Generator;
+
+use CG\Generator\PhpFunction;
+use PHPUnit\Framework\TestCase;
+
+class Php71FunctionTest extends TestCase
+{
+    public function testReturnNullableBuiltInType()
+    {
+        $method = new PhpFunction();
+
+        $this->assertFalse($method->hasBuiltInReturnType());
+        $this->assertSame($method, $method->setReturnType('?string'));
+        $this->assertTrue($method->hasBuiltInReturnType());
+    }
+
+
+    public function testItCreatesNullableInTypeFromReflection()
+    {
+        $f = function ():?string {
+            return '';
+        };
+        $reflection = new \ReflectionFunction($f);
+
+        $method = PhpFunction::fromReflection($reflection);
+
+        $this->assertTrue($method->hasBuiltInReturnType());
+        $this->assertSame('?string', $method->getReturnType());
+    }
+
+}

--- a/tests/CG/Tests/Generator/Php71MethodTest.php
+++ b/tests/CG/Tests/Generator/Php71MethodTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CG\Tests\Generator;
+
+use CG\Generator\PhpParameter;
+use CG\Generator\PhpMethod;
+use PHPUnit\Framework\TestCase;
+
+class Php71MethodTest extends TestCase
+{
+    public function testReturnNullableBuiltInType()
+    {
+        $method = new PhpMethod();
+
+        $this->assertFalse($method->hasBuiltInReturnType());
+        $this->assertSame($method, $method->setReturnType('?string'));
+        $this->assertTrue($method->hasBuiltInReturnType());
+    }
+
+
+    public function testItCreatesNullableInTypeFromReflection()
+    {
+        $class = new class
+        {
+            public function iAmNullable():?string
+            {
+                return '';
+            }
+        };
+        $reflection = (new \ReflectionClass($class))->getMethod('iAmNullable');
+
+        $method = PhpMethod::fromReflection($reflection);
+
+        $this->assertTrue($method->hasBuiltInReturnType());
+        $this->assertSame('?string', $method->getReturnType());
+    }
+
+}

--- a/tests/CG/Tests/Generator/Php71ParameterTest.php
+++ b/tests/CG/Tests/Generator/Php71ParameterTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CG\Tests\Generator;
+
+use CG\Generator\PhpFunction;
+use CG\Generator\PhpParameter;
+use CG\Generator\PhpMethod;
+use PHPUnit\Framework\TestCase;
+
+class Php71ParameterTest extends TestCase
+{
+    public function testReturnNullableBuiltInType()
+    {
+        $method = new PhpParameter();
+
+        $this->assertFalse($method->hasBuiltinType());
+        $this->assertSame($method, $method->setType('?string'));
+        $this->assertTrue($method->hasBuiltinType());
+    }
+
+
+    public function testItCreatesNullableInTypeFromReflection()
+    {
+        $f = function (?string $param) {
+        };
+        $reflection = (new \ReflectionFunction($f))->getParameters()[0];
+
+        $method = PhpParameter::fromReflection($reflection);
+
+        $this->assertTrue($method->hasBuiltinType());
+        $this->assertSame('?string', $method->getType());
+    }
+
+}


### PR DESCRIPTION
Hey @schmittjoh !
I've created a small PR to add support for nullable params & return types, that comes with PHP7.1. 

Would it be possible to merge it and release, please? 