### PR TITLE
Php73 compatibility

### DIFF
--- a/src/CG/Generator/DefaultVisitor.php
+++ b/src/CG/Generator/DefaultVisitor.php
@@ -189,7 +189,7 @@ class DefaultVisitor implements DefaultVisitorInterface
         if ($method->hasReturnType()) {
             $type = $method->getReturnType();
             $this->writer->write(': ');
-            if (!$method->hasBuiltInReturnType() && '\\' !== $type[0]) {
+            if (!$method->hasBuiltInReturnType() && '\\' !== $type[0] && $type !== 'self') {
                 $this->writer->write('\\');
             }
             $this->writer->write($type);
@@ -277,7 +277,7 @@ class DefaultVisitor implements DefaultVisitorInterface
                 if ($parameter->isNullable()) {
                     $this->writer->write('?');
                 }
-                if (!$parameter->hasBuiltinType() && '\\' !== $type[0]) {
+                if (!$parameter->hasBuiltinType() && '\\' !== $type[0] && $type !== 'self') {
                     $this->writer->write('\\');
                 }
                 $this->writer->write($type . ' ');

--- a/src/CG/Generator/DefaultVisitor.php
+++ b/src/CG/Generator/DefaultVisitor.php
@@ -274,6 +274,9 @@ class DefaultVisitor implements DefaultVisitorInterface
 
             if ($parameter->hasType()) {
                 $type = $parameter->getType();
+                if ($parameter->isNullable()) {
+                    $this->writer->write('?');
+                }
                 if (!$parameter->hasBuiltinType() && '\\' !== $type[0]) {
                     $this->writer->write('\\');
                 }

--- a/src/CG/Generator/DefaultVisitor.php
+++ b/src/CG/Generator/DefaultVisitor.php
@@ -189,6 +189,9 @@ class DefaultVisitor implements DefaultVisitorInterface
         if ($method->hasReturnType()) {
             $type = $method->getReturnType();
             $this->writer->write(': ');
+            if ($method->allowsNullReturn()) {
+                $this->writer->write('?');
+            }
             if (!$method->hasBuiltInReturnType() && '\\' !== $type[0] && $type !== 'self') {
                 $this->writer->write('\\');
             }
@@ -241,6 +244,9 @@ class DefaultVisitor implements DefaultVisitorInterface
         if ($function->hasReturnType()) {
             $type = $function->getReturnType();
             $this->writer->write(': ');
+            if ($function->allowsNullReturn()) {
+                $this->writer->write('?');
+            }
             if (!$function->hasBuiltinReturnType() && '\\' !== $type[0]) {
                 $this->writer->write('\\');
             }

--- a/src/CG/Generator/PhpFunction.php
+++ b/src/CG/Generator/PhpFunction.php
@@ -49,7 +49,7 @@ class PhpFunction extends AbstractBuilder
 
         if (method_exists($ref, 'getReturnType')) {
             if ($type = $ref->getReturnType()) {
-                $function->setReturnType((string)$type);
+                $function->setReturnType($type);
             }
         }
         $function->referenceReturned = $ref->returnsReference();
@@ -135,8 +135,8 @@ class PhpFunction extends AbstractBuilder
 
     public function setReturnType($type)
     {
-        $this->returnType = $type;
-        $this->returnTypeBuiltin = BuiltinType::isBuiltIn($type);
+        $this->returnType = (string)$type;
+        $this->returnTypeBuiltin = $type->isBuiltin();
         return $this;
     }
 

--- a/src/CG/Generator/PhpFunction.php
+++ b/src/CG/Generator/PhpFunction.php
@@ -35,6 +35,7 @@ class PhpFunction extends AbstractBuilder
     private $docblock;
     private $returnType;
     private $returnTypeBuiltin = false;
+    private $returnTypeAllowsNull = false;
 
     public static function fromReflection(\ReflectionFunction $ref)
     {
@@ -137,6 +138,7 @@ class PhpFunction extends AbstractBuilder
     {
         $this->returnType = (string)$type;
         $this->returnTypeBuiltin = $type->isBuiltin();
+        $this->returnTypeAllowsNull = $type->allowsNull();
         return $this;
     }
 
@@ -276,4 +278,8 @@ class PhpFunction extends AbstractBuilder
         return $this->returnTypeBuiltin;
     }
 
+    public function allowsNullReturn()
+    {
+        return $this->returnTypeAllowsNull;
+    }
 }

--- a/src/CG/Generator/PhpMethod.php
+++ b/src/CG/Generator/PhpMethod.php
@@ -57,7 +57,7 @@ class PhpMethod extends AbstractPhpMember
 
         if (method_exists($ref, 'getReturnType')) {
             if ($type = $ref->getReturnType()) {
-                $method->setReturnType((string)$type);
+                $method->setReturnType($type);
             }
         }
 
@@ -137,8 +137,8 @@ class PhpMethod extends AbstractPhpMember
 
     public function setReturnType($type)
     {
-        $this->returnType = $type;
-        $this->returnTypeBuiltin = BuiltinType::isBuiltin($type);
+        $this->returnType = (string)$type;
+        $this->returnTypeBuiltin = $type->isBuiltin();
         return $this;
     }
 

--- a/src/CG/Generator/PhpMethod.php
+++ b/src/CG/Generator/PhpMethod.php
@@ -32,6 +32,7 @@ class PhpMethod extends AbstractPhpMember
     private $parameters = array();
     private $referenceReturned = false;
     private $returnType = null;
+    private $returnTypeAllowsNull = false;
     private $returnTypeBuiltin = false;
     private $body = '';
 
@@ -139,6 +140,7 @@ class PhpMethod extends AbstractPhpMember
     {
         $this->returnType = (string)$type;
         $this->returnTypeBuiltin = $type->isBuiltin();
+        $this->returnTypeAllowsNull = $type->allowsNull();
         return $this;
     }
 
@@ -230,5 +232,10 @@ class PhpMethod extends AbstractPhpMember
     public function hasBuiltInReturnType()
     {
         return $this->returnTypeBuiltin;
+    }
+
+    public function allowsNullReturn()
+    {
+        return $this->returnTypeAllowsNull;
     }
 }

--- a/src/CG/Proxy/InterceptionGenerator.php
+++ b/src/CG/Proxy/InterceptionGenerator.php
@@ -113,7 +113,8 @@ class InterceptionGenerator implements GeneratorInterface
             $params = implode(', ', $params);
 
             $genMethod = PhpMethod::fromReflection($method);
-            $isVoid = 'void' === $genMethod->getReturnType();
+            $isVoid = $genMethod->hasBuiltInReturnType()
+                && 'void' === $genMethod->getReturnType();
 
             $genMethod->setBody(
                     sprintf(

--- a/src/CG/Proxy/InterceptionGenerator.php
+++ b/src/CG/Proxy/InterceptionGenerator.php
@@ -98,8 +98,12 @@ class InterceptionGenerator implements GeneratorInterface
              '$ref = new \ReflectionMethod(%s, %s);'."\n"
             .'$interceptors = $this->'.$this->prefix.'loader->loadInterceptors($ref, $this, array(%s));'."\n"
             .'$invocation = new \CG\Proxy\MethodInvocation($ref, $this, array(%s), $interceptors);'."\n\n"
-            .'return $invocation->proceed();'
         ;
+
+        $voidReturns = array(
+            true => '$invocation->proceed();',
+            false => 'return $invocation->proceed();'
+        );
 
         foreach ($methods as $method) {
             $params = array();
@@ -108,9 +112,18 @@ class InterceptionGenerator implements GeneratorInterface
             }
             $params = implode(', ', $params);
 
-            $genMethod = PhpMethod::fromReflection($method)
-                ->setBody(sprintf($interceptorCode, var_export(ClassUtils::getUserClass($method->class), true), var_export($method->name, true), $params, $params))
-                ->setDocblock(null)
+            $genMethod = PhpMethod::fromReflection($method);
+            $isVoid = 'void' === $genMethod->getReturnType();
+
+            $genMethod->setBody(
+                    sprintf(
+                        $interceptorCode . $voidReturns[$isVoid],
+                        var_export(ClassUtils::getUserClass($method->class), true),
+                        var_export($method->name, true),
+                        $params,
+                        $params
+                    )
+                )->setDocblock(null)
             ;
             $genClass->setMethod($genMethod);
         }

--- a/tests/CG/Tests/Generator/DefaultVisitorTest.php
+++ b/tests/CG/Tests/Generator/DefaultVisitorTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace CG\Tests\Generator;
 
-require_once(dirname(__FILE__).'/Fixture/DummyReflectionTypes.php');
+if (PHP_VERSION_ID >= 70000) {
+    require_once(dirname(__FILE__).'/Fixture/DummyReflectionTypes.php');
+}
 
 use CG\Core\DefaultGeneratorStrategy;
 use CG\Generator\DefaultVisitor;

--- a/tests/CG/Tests/Generator/DefaultVisitorTest.php
+++ b/tests/CG/Tests/Generator/DefaultVisitorTest.php
@@ -1,6 +1,7 @@
 <?php
-
 namespace CG\Tests\Generator;
+
+require_once(dirname(__FILE__).'/Fixture/DummyReflectionTypes.php');
 
 use CG\Core\DefaultGeneratorStrategy;
 use CG\Generator\DefaultVisitor;
@@ -107,10 +108,14 @@ class DefaultVisitorTest extends \PHPUnit_Framework_TestCase
 
     public function visitFunctionWithPhp7FeaturesDataProvider()
     {
+        if (PHP_VERSION_ID < 70000) {
+            return array();
+        }
+
         $builtinReturn = PhpFunction::create('foo')
-                            ->setReturnType('bool');
+                            ->setReturnType(getBoolReflectionType());
         $nonbuiltinReturn = PhpFunction::create('foo')
-                            ->setReturnType('\Foo');
+                            ->setReturnType(getFooReflectionType());
 
 
         return array(

--- a/tests/CG/Tests/Generator/Fixture/DummyReflectionTypes.php
+++ b/tests/CG/Tests/Generator/Fixture/DummyReflectionTypes.php
@@ -1,0 +1,80 @@
+<?php
+require_once(dirname(__FILE__).'/EntityPhp7.php');
+require_once(dirname(__FILE__).'/SubFixture/Foo.php');
+require_once(dirname(__FILE__).'/SubFixture/Bar.php');
+require_once(dirname(__FILE__).'/SubFixture/Baz.php');
+
+function dummyReturnArray(): array {
+    return array();
+}
+
+function dummyReturnBar(): CG\Tests\Generator\Fixture\SubFixture\Bar
+{
+    return new CG\Tests\Generator\Fixture\SubFixture\Bar();
+}
+
+function dummyReturnBaz(): CG\Tests\Generator\Fixture\SubFixture\Baz
+{
+    return new CG\Tests\Generator\Fixture\SubFixture\Baz();
+}
+
+function dummyReturnBool(): bool {
+    return true;
+}
+
+function dummyReturnDateTime(): DateTime {
+    return new DateTime();
+}
+
+function dummyReturnDateTimeZone(): DateTimeZone {
+    return new DateTimeZone();
+}
+
+function dummyReturnEntityPhp7(): CG\Tests\Generator\Fixture\EntityPhp7 {
+    return new CG\Tests\Generator\Fixture\EntityPhp7();
+}
+
+function dummyReturnFoo(): CG\Tests\Generator\Fixture\SubFixture\Foo
+{
+    return new CG\Tests\Generator\Fixture\SubFixture\Foo();
+}
+
+function dummyReturnInt(): int {
+    return 1;
+}
+
+function getArrayReflectionType() {
+    return (new ReflectionFunction('dummyReturnArray'))->getReturnType();
+}
+
+function getBarReflectionType() {
+    return (new ReflectionFunction('dummyReturnBar'))->getReturnType();
+}
+
+function getBazReflectionType() {
+    return (new ReflectionFunction('dummyReturnBaz'))->getReturnType();
+}
+
+function getBoolReflectionType() {
+    return (new ReflectionFunction('dummyReturnBool'))->getReturnType();
+}
+
+function getDateTimeReflectionType() {
+    return (new ReflectionFunction('dummyReturnDateTime'))->getReturnType();
+}
+
+function getDateTimeZoneReflectionType() {
+    return (new ReflectionFunction('dummyReturnDateTimeZone'))->getReturnType();
+}
+
+function getEntityPhp7ReflectionType() {
+    return (new ReflectionFunction('dummyReturnEntityPhp7'))->getReturnType();
+}
+
+function getFooReflectionType() {
+    return (new ReflectionFunction('dummyReturnFoo'))->getReturnType();
+}
+
+function getIntReflectionType() {
+    return (new ReflectionFunction('dummyReturnInt'))->getReturnType();
+}

--- a/tests/CG/Tests/Generator/Fixture/DummyReflectionTypes.php
+++ b/tests/CG/Tests/Generator/Fixture/DummyReflectionTypes.php
@@ -43,6 +43,10 @@ function dummyReturnInt(): int {
     return 1;
 }
 
+function dummyReturnVoid(): void {
+    // Do nothing;
+}
+
 function getArrayReflectionType() {
     return (new ReflectionFunction('dummyReturnArray'))->getReturnType();
 }
@@ -77,4 +81,8 @@ function getFooReflectionType() {
 
 function getIntReflectionType() {
     return (new ReflectionFunction('dummyReturnInt'))->getReturnType();
+}
+
+function getVoidReflectionType() {
+    return (new ReflectionFunction('dummyReturnVoid'))->getReturnType();
 }

--- a/tests/CG/Tests/Generator/Fixture/DummyReflectionTypes.php
+++ b/tests/CG/Tests/Generator/Fixture/DummyReflectionTypes.php
@@ -4,6 +4,10 @@ require_once(dirname(__FILE__).'/SubFixture/Foo.php');
 require_once(dirname(__FILE__).'/SubFixture/Bar.php');
 require_once(dirname(__FILE__).'/SubFixture/Baz.php');
 
+function dummyNullableReturnString(): ?string {
+    return null;
+}
+
 function dummyReturnArray(): array {
     return array();
 }
@@ -81,6 +85,10 @@ function getFooReflectionType() {
 
 function getIntReflectionType() {
     return (new ReflectionFunction('dummyReturnInt'))->getReturnType();
+}
+
+function getNullableStringReflectionType() {
+    return (new ReflectionFunction('dummyNullableReturnString'))->getReturnType();
 }
 
 function getVoidReflectionType() {

--- a/tests/CG/Tests/Generator/Fixture/EntityPhp7.php
+++ b/tests/CG/Tests/Generator/Fixture/EntityPhp7.php
@@ -31,7 +31,7 @@ class EntityPhp7
      * @param int $id
      * @return EntityPhp7
      */
-    public function setId(int $id = null): self
+    public function setId(int $id = null): EntityPhp7
     {
         $this->id = $id;
         return $this;

--- a/tests/CG/Tests/Generator/Fixture/EntityPhp73.php
+++ b/tests/CG/Tests/Generator/Fixture/EntityPhp73.php
@@ -17,4 +17,8 @@ class EntityPhp73
     public function doNothing() : void {
         // Do nothing
     }
+
+    public function doNothing2() : ?string {
+        return null;
+    }
 }

--- a/tests/CG/Tests/Generator/Fixture/EntityPhp73.php
+++ b/tests/CG/Tests/Generator/Fixture/EntityPhp73.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace CG\Tests\Generator\Fixture;
+
+use \DateTime;
+
+use CG\Tests\Generator\Fixture\SubFixture\Foo;
+use CG\Tests\Generator\Fixture\SubFixture as Sub;
+
+/**
+ * Doc Comment.
+ *
+ * @author Igor Blanco <iblanco@binovo.es>
+ */
+class EntityPhp73
+{
+    public function doNothing() : void {
+        // Do nothing
+    }
+}

--- a/tests/CG/Tests/Generator/Fixture/generated/php7_class.php
+++ b/tests/CG/Tests/Generator/Fixture/generated/php7_class.php
@@ -24,7 +24,7 @@ class EntityPhp7
      * @param int $id
      * @return EntityPhp7
      */
-    public function setId(int $id = NULL): self
+    public function setId(int $id = NULL): \CG\Tests\Generator\Fixture\EntityPhp7
     {
     }
 

--- a/tests/CG/Tests/Generator/Fixture/generated/php7_func_nonbuiltin_return.php
+++ b/tests/CG/Tests/Generator/Fixture/generated/php7_func_nonbuiltin_return.php
@@ -1,3 +1,3 @@
-function foo(): \Foo
+function foo(): \CG\Tests\Generator\Fixture\SubFixture\Foo
 {
 }

--- a/tests/CG/Tests/Generator/Php73ClassTest.php
+++ b/tests/CG/Tests/Generator/Php73ClassTest.php
@@ -33,6 +33,12 @@ class Php73ClassTest extends \PHPUnit_Framework_TestCase
             ->setReturnType(getVoidReflectionType())
         );
 
+        $class->setMethod(PhpMethod::create()
+            ->setName('doNothing2')
+            ->setVisibility('public')
+            ->setReturnType(getNullableStringReflectionType())
+        );
+
         $this->assertEquals($class, PhpClass::fromReflection(new \ReflectionClass('CG\Tests\Generator\Fixture\EntityPhp73')));
     }
 }

--- a/tests/CG/Tests/Generator/Php73ClassTest.php
+++ b/tests/CG/Tests/Generator/Php73ClassTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace CG\Tests\Generator;
+
+if (PHP_VERSION_ID >= 70300) {
+    require_once(dirname(__FILE__).'/Fixture/DummyReflectionTypes.php');
+}
+
+use CG\Generator\PhpProperty;
+use CG\Generator\PhpParameter;
+use CG\Generator\PhpMethod;
+use CG\Generator\PhpClass;
+
+class Php73ClassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFromReflection()
+    {
+        if (PHP_VERSION_ID < 70300) {
+           $this->markTestSkipped("Test is only valid for PHP >=7.3");
+        }
+        $class = new PhpClass();
+        $class
+            ->setName('CG\Tests\Generator\Fixture\EntityPhp73')
+            ->setDocblock('/**
+ * Doc Comment.
+ *
+ * @author Igor Blanco <iblanco@binovo.es>
+ */'
+             );
+
+        $class->setMethod(PhpMethod::create()
+            ->setName('doNothing')
+            ->setVisibility('public')
+            ->setReturnType(getVoidReflectionType())
+        );
+
+        $this->assertEquals($class, PhpClass::fromReflection(new \ReflectionClass('CG\Tests\Generator\Fixture\EntityPhp73')));
+    }
+}

--- a/tests/CG/Tests/Generator/Php7ClassTest.php
+++ b/tests/CG/Tests/Generator/Php7ClassTest.php
@@ -1,6 +1,7 @@
 <?php
-
 namespace CG\Tests\Generator;
+
+require_once(dirname(__FILE__).'/Fixture/DummyReflectionTypes.php');
 
 use CG\Generator\PhpProperty;
 use CG\Generator\PhpParameter;
@@ -36,7 +37,7 @@ class Php7ClassTest extends \PHPUnit_Framework_TestCase
  * @return int
  */')
             ->setVisibility('public')
-            ->setReturnType('int')
+            ->setReturnType(getIntReflectionType())
         );
 
         $class->setMethod(PhpMethod::create()
@@ -51,19 +52,19 @@ class Php7ClassTest extends \PHPUnit_Framework_TestCase
                     ->setType('int')
                     ->setDefaultValue(null)
             )
-            ->setReturnType('self')
+            ->setReturnType(getEntityPhp7ReflectionType())
         );
 
         $class->setMethod(PhpMethod::create()
             ->setName('getTime')
             ->setVisibility('public')
-            ->setReturnType('DateTime')
+            ->setReturnType(getDateTimeReflectionType())
         );
 
         $class->setMethod(PhpMethod::create()
             ->setName('getTimeZone')
             ->setVisibility('public')
-            ->setReturnType('DateTimeZone')
+            ->setReturnType(getDateTimeZoneReflectionType())
         );
 
         $class->setMethod(PhpMethod::create()
@@ -87,7 +88,7 @@ class Php7ClassTest extends \PHPUnit_Framework_TestCase
         $class->setMethod(PhpMethod::create()
             ->setName('setArray')
             ->setVisibility('public')
-            ->setReturnType('array')
+            ->setReturnType(getArrayReflectionType())
             ->addParameter(PhpParameter::create()
                 ->setName('array')
                 ->setDefaultValue(null)
@@ -98,17 +99,17 @@ class Php7ClassTest extends \PHPUnit_Framework_TestCase
 
         $class->setMethod(PhpMethod::create()
             ->setName('getFoo')
-            ->setReturnType('CG\Tests\Generator\Fixture\SubFixture\Foo')
+            ->setReturnType(getFooReflectionType())
         );
 
         $class->setMethod(PhpMethod::create()
             ->setName('getBar')
-            ->setReturnType('CG\Tests\Generator\Fixture\SubFixture\Bar')
+            ->setReturnType(getBarReflectionType())
         );
 
         $class->setMethod(PhpMethod::create()
             ->setName('getBaz')
-            ->setReturnType('CG\Tests\Generator\Fixture\SubFixture\Baz')
+            ->setReturnType(getBazReflectionType())
         );
 
         $this->assertEquals($class, PhpClass::fromReflection(new \ReflectionClass('CG\Tests\Generator\Fixture\EntityPhp7')));

--- a/tests/CG/Tests/Generator/Php7ClassTest.php
+++ b/tests/CG/Tests/Generator/Php7ClassTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace CG\Tests\Generator;
 
-require_once(dirname(__FILE__).'/Fixture/DummyReflectionTypes.php');
+if (PHP_VERSION_ID >= 70000) {
+    require_once(dirname(__FILE__).'/Fixture/DummyReflectionTypes.php');
+}
 
 use CG\Generator\PhpProperty;
 use CG\Generator\PhpParameter;


### PR DESCRIPTION
Fixes compatibility issues with new syntax introduced in PHP 7.0 and 7.3
It does so by maintaining backwards compatibilidy with PHP 5.

When available uses ReflectionType in order to allow the use of nullable parameters. If it is not available that means that we are using PHP prior to 7 so no nullable parameters should exists.
ReflectionType does not allow to distinguish parameter "int $a=null" from "?int $a=null" but in fact they are equivalent and compatible signatures so in this case we prefer "int $a=null" to maintain compatibility with PHP 7.0.

The return values are always set using ReflectionType so it supports also built-in type "void" that was introduced in PHP 7.3 . Of course apart from using ReflectionType InterceptionGeneration was slightly modified to achieve this. Heavily inspired by https://github.com/SymfonyRotEbal/cg-library/commit/7bcc767cedbb45295498a97ff513e46ecee7f197

A new test was added to check the generation of method with ": void"

Fixes #35 