### PR TITLE
getName before getType, for PHP 7.4 compability.

### DIFF
--- a/src/CG/Generator/PhpParameter.php
+++ b/src/CG/Generator/PhpParameter.php
@@ -52,8 +52,12 @@ class PhpParameter extends AbstractBuilder
             $parameter->setDefaultValue($ref->getDefaultValue());
         }
 
-        if (method_exists($ref, 'getType')) {
-            if ($type = $ref->getType()) {
+        if (method_exists($ref, 'getName')) {
+          if ($type = $ref->getName()) {
+              $parameter->setType($type);
+          }
+        } else if (method_exists($ref, 'getType')) {
+          if ($type = $ref->getType()) {
                 $parameter->setType((string)$type);
             }
         } else {


### PR DESCRIPTION
Fixes Deprecation Warning for PHP 7.4.
Now compatible with < 7.3.