### PR TITLE
Add support for nullable arguments and return types

### DIFF
--- a/src/CG/Generator/BuiltinType.php
+++ b/src/CG/Generator/BuiltinType.php
@@ -4,7 +4,7 @@ namespace CG\Generator;
 
 class BuiltinType
 {
-    private static $builtinTypes = array('self', 'array', 'callable', 'bool', 'float', 'int', 'string');
+    private static $builtinTypes = array('self', 'array', 'callable', 'bool', 'float', 'int', 'string', 'void');
     
     private function __construct(){
         // Static class

--- a/src/CG/Generator/DefaultVisitor.php
+++ b/src/CG/Generator/DefaultVisitor.php
@@ -189,6 +189,11 @@ class DefaultVisitor implements DefaultVisitorInterface
         if ($method->hasReturnType()) {
             $type = $method->getReturnType();
             $this->writer->write(': ');
+
+            if ($method->isReturnNullable()) {
+                $this->writer->write('?');
+            }
+            
             if (!$method->hasBuiltInReturnType() && '\\' !== $type[0]) {
                 $this->writer->write('\\');
             }
@@ -241,6 +246,11 @@ class DefaultVisitor implements DefaultVisitorInterface
         if ($function->hasReturnType()) {
             $type = $function->getReturnType();
             $this->writer->write(': ');
+            
+            if ($function->isReturnNullable()) {
+                $this->writer->write('?');
+            }
+            
             if (!$function->hasBuiltinReturnType() && '\\' !== $type[0]) {
                 $this->writer->write('\\');
             }
@@ -266,6 +276,7 @@ class DefaultVisitor implements DefaultVisitorInterface
     private function writeParameters(array $parameters)
     {
         $first = true;
+        /** @var PhpParameter $parameter */
         foreach ($parameters as $parameter) {
             if (!$first) {
                 $this->writer->write(', ');
@@ -274,6 +285,9 @@ class DefaultVisitor implements DefaultVisitorInterface
 
             if ($parameter->hasType()) {
                 $type = $parameter->getType();
+                if ($parameter->isNullable()) {
+                    $this->writer->write('?');
+                }
                 if (!$parameter->hasBuiltinType() && '\\' !== $type[0]) {
                     $this->writer->write('\\');
                 }

--- a/src/CG/Generator/PhpFunction.php
+++ b/src/CG/Generator/PhpFunction.php
@@ -35,6 +35,24 @@ class PhpFunction extends AbstractBuilder
     private $docblock;
     private $returnType;
     private $returnTypeBuiltin = false;
+    private $returnNullable = false;
+
+    /**
+     * @return bool
+     */
+    public function isReturnNullable(): ?bool
+    {
+        return $this->returnNullable;
+    }
+
+    /**
+     * @param bool $returnNullable
+     * @return void
+     */
+    public function setReturnNullable(bool $returnNullable): void
+    {
+        $this->returnNullable = $returnNullable;
+    }
 
     public static function fromReflection(\ReflectionFunction $ref)
     {
@@ -50,6 +68,7 @@ class PhpFunction extends AbstractBuilder
         if (method_exists($ref, 'getReturnType')) {
             if ($type = $ref->getReturnType()) {
                 $function->setReturnType((string)$type);
+                $function->setReturnNullable($type->allowsNull());
             }
         }
         $function->referenceReturned = $ref->returnsReference();

--- a/src/CG/Generator/PhpMethod.php
+++ b/src/CG/Generator/PhpMethod.php
@@ -34,6 +34,7 @@ class PhpMethod extends AbstractPhpMember
     private $returnType = null;
     private $returnTypeBuiltin = false;
     private $body = '';
+    private $returnNullable = false;
 
     /**
      * @param string|null $name
@@ -41,6 +42,23 @@ class PhpMethod extends AbstractPhpMember
     public static function create($name = null)
     {
         return new static($name);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isReturnNullable(): ?bool
+    {
+        return $this->returnNullable;
+    }
+
+    /**
+     * @param bool $returnNullable
+     * @return void
+     */
+    public function setReturnNullable(bool $returnNullable): void
+    {
+        $this->returnNullable = $returnNullable;
     }
 
     public static function fromReflection(\ReflectionMethod $ref)
@@ -57,7 +75,8 @@ class PhpMethod extends AbstractPhpMember
 
         if (method_exists($ref, 'getReturnType')) {
             if ($type = $ref->getReturnType()) {
-                $method->setReturnType((string)$type);
+                $method->setReturnType((string)$type, $type->allowsNull());
+                $method->setReturnNullable($type->allowsNull());
             }
         }
 
@@ -135,7 +154,7 @@ class PhpMethod extends AbstractPhpMember
         return $this;
     }
 
-    public function setReturnType($type)
+    public function setReturnType($type, $allowsNull = false)
     {
         $this->returnType = $type;
         $this->returnTypeBuiltin = BuiltinType::isBuiltin($type);

--- a/src/CG/Generator/PhpParameter.php
+++ b/src/CG/Generator/PhpParameter.php
@@ -31,6 +31,24 @@ class PhpParameter extends AbstractBuilder
     private $passedByReference = false;
     private $type;
     private $typeBuiltin;
+    private $nullable;
+
+    /**
+     * @return mixed
+     */
+    public function isNullable()
+    {
+        return $this->nullable;
+    }
+
+    /**
+     * @param mixed $nullable
+     * @return void
+     */
+    public function setNullable(bool $nullable): void
+    {
+        $this->nullable = $nullable;
+    }
 
     /**
      * @param string|null $name
@@ -46,6 +64,7 @@ class PhpParameter extends AbstractBuilder
         $parameter
             ->setName($ref->name)
             ->setPassedByReference($ref->isPassedByReference())
+            ->setNullable($ref->allowsNull())
         ;
 
         if ($ref->isDefaultValueAvailable()) {
@@ -113,7 +132,7 @@ class PhpParameter extends AbstractBuilder
     /**
      * @param string $type
      */
-    public function setType($type)
+    public function setType($type, $allowsNull = false)
     {
         $this->type = $type;
         $this->typeBuiltin = BuiltinType::isBuiltIn($type);


### PR DESCRIPTION
Add support for PHP 7.4+ nullable method and function arguments and return types.

Additionally change interceptor code template to allow empty interceptors array. Otherwise a fatal error is thrown when proxy target class calls it's own public methods within a constructor.

Fix interceptor code to return function return value only if function is not marked with void return type.